### PR TITLE
fix: 번역 결과 창이 나와있을 때 텍스트 선택되는 버그 수정

### DIFF
--- a/src/components/TextSelection.jsx
+++ b/src/components/TextSelection.jsx
@@ -49,7 +49,10 @@ export default function TextSelection() {
 
     const handleMouseup = ({ pageX, pageY }) => {
       setIsSelectionEnd(true);
-      setTextSelected(document.getSelection().toString().trim());
+
+      if (!isBoxVisible) {
+        setTextSelected(document.getSelection().toString().trim());
+      }
 
       if (!isButtonClicked) {
         setBoxPosition({ left: pageX, top: pageY });

--- a/test/Popup.test.js
+++ b/test/Popup.test.js
@@ -1,0 +1,5 @@
+/* eslint-disable no-undef */
+
+test("first test", () => {
+  expect(1).toEqual(1);
+});


### PR DESCRIPTION
문제: 결과 창이 나와있을 때 텍스트가 계속 선택되어 만약 빈 문자열로, "내 용어집으로 번역하기" 요청이 됐을 경우, 에러가 발생했습니다.
해결: 번역 결과창이 보이고 있을 때는 텍스트가 선택되지 않도록 막았습니다.
